### PR TITLE
Update utils.py for compatibility with Django 1.10 +

### DIFF
--- a/inspect_model/utils.py
+++ b/inspect_model/utils.py
@@ -71,8 +71,10 @@ class InspectModel(object):
         self.many_fields = set()
         opts = getattr(self.model, '_meta', None)
         if opts:
-            for f in opts.get_all_field_names():
-                field, model, direct, m2m = opts.get_field_by_name(f)
+            for field in opts.get_fields():
+            	model = field.model
+            	direct = not field.auto_created or field.concrete
+            	m2m = field.many_to_many
                 if not direct:  # relation or many field from another model
                     name = field.get_accessor_name()
                     field = field.field


### PR DESCRIPTION
Updated for compatibility with Django 1.10 +
Replaced the get_all_field_names and get_field_by_name methods, which have been removed from the Model._meta API.
https://docs.djangoproject.com/en/2.0/ref/models/meta/#migrating-from-the-old-api